### PR TITLE
Remove possibly problematic TODO comment

### DIFF
--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -2526,7 +2526,7 @@ void ReadyForInstallationPage::entering()
         qDebug().nospace() << "Cannot determine available space on device. "
                               "Volume descriptor: " << targetVolume.volumeDescriptor()
                            << ", Mount path: " << targetVolume.mountPath() << ". Continue silently.";
-        return;     // TODO: Shouldn't this also disable the "Next" button?
+        return;
     }
 
     const bool tempOnSameVolume = (targetVolume == tempVolume);


### PR DESCRIPTION
Running qt installer instance Docker always falls into a case of not being able to define volume size. Hence just in case, let's remove a TODO comment that hints to block `Next` button.