### PR TITLE
UninstallString does not work in Windows

### DIFF
--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -2824,7 +2824,7 @@ void PackageManagerCorePrivate::registerMaintenanceTool()
     settings.setValue(QLatin1String("Comments"), m_data.value(scTitle));
     settings.setValue(QLatin1String("InstallDate"), QDateTime::currentDateTime().toString());
     settings.setValue(QLatin1String("InstallLocation"), QDir::toNativeSeparators(targetDir()));
-    settings.setValue(QLatin1String("UninstallString"), QString(quoted(maintenanceTool)
+    settings.setValue(QLatin1String("UninstallString"), "CMD /C" + QString(quoted(maintenanceTool)
         + QLatin1String(" --") + CommandLineOptions::scStartUninstallerLong));
     if (!isOfflineOnly()) {
         settings.setValue(QLatin1String("ModifyPath"), QString(quoted(maintenanceTool)


### PR DESCRIPTION
Windows built-in remove app will execute windows registry key "UninstallString",  but it does not work on Windows OS now.

The working version should be like

CMD /C "xxxx.maintenance.exe" 